### PR TITLE
indicate that Factory must be used in the require

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Rosie is a factory for building JavaScript objects, mostly useful for setting up
 Define your factory, giving it a name and optionally a constructor function:
 
 ```js
+var Factory = require('rosie').Factory;
+
 Factory.define('game', Game)
   .sequence('id')
   .attr('is_over', false)


### PR DESCRIPTION
It is difficult to realize at first glance at the README that this line is necessary without diving through the source. This change would easily mitigate that problem.