### PR TITLE
Avoid shared state between factory invocation when using buildList

### DIFF
--- a/spec/javascripts/rosie.spec.js
+++ b/spec/javascripts/rosie.spec.js
@@ -138,6 +138,16 @@ describe('Factory', function() {
         expect(things[i]).toEqual({id: i + 1, name: 'changed'});
       }
     });
+
+    it('should evaluate a option for every member of the list', function() {
+      Factory.define('thing')
+        .option('random', function() { return Math.random(); })
+        .attr('number', ['random'], function(random) {
+          return random;
+        });
+      var things = Factory.buildList('thing', 2, {}, {});
+      expect(things[0].number).not.toEqual(things[1].number);
+    });
   });
 
   describe('extend', function() {

--- a/src/rosie.js
+++ b/src/rosie.js
@@ -369,7 +369,34 @@ Factory.util = (function() {
         }
       }
       return dest;
+    },
+
+    /**
+     * Clone a object and return a new instance.
+     * As in http://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-clone-an-object/122190#122190
+     *
+     * @private
+     * @param {object} obj
+     * @return {object}
+     */
+    clone: function(obj) {
+      if(obj === null || typeof(obj) !== 'object' || 'isActiveClone' in obj) {
+        return obj;
+      }
+
+      var temp = obj.constructor(); // changed
+
+      for(var key in obj) {
+        if(Object.prototype.hasOwnProperty.call(obj, key)) {
+          obj['isActiveClone'] = null;
+          temp[key] = Factory.util.clone(obj[key]);
+          delete obj['isActiveClone'];
+        }
+      }
+
+      return temp;
     }
+    
   };
 })();
 
@@ -415,7 +442,11 @@ Factory.build = function(name, attributes, options) {
 Factory.buildList = function(name, size, attributes, options) {
   var objs = [];
   for (var i = 0; i < size; i++) {
-    objs.push(Factory.build(name, attributes, options));
+    objs.push(Factory.build(
+      name, 
+      Factory.util.clone(attributes), 
+      Factory.util.clone(options)
+    ));
   }
   return objs;
 };


### PR DESCRIPTION
One problem I have is when build a list of objects with options that need to be generated on the fly. Example:
```javascript
var counter = 0;
Factory.define('thing')
    .option('counter', function() { return counter++; })
    .attr('number', ['counter'], function(counter) {
      return counter;
    });
```
In this case every time I build a new thing, using `Factory.build`, a new number will be generated based on the counter. The expected behavior. But this is not true when using `Factory.buildList` method with options parameters.

```javascript
Factory.buildList('thing', 2); // works fine
// thing[0].number === 0
// thing[1].number === 1

Factory.buildList('thing', 2, {}, {}); // doesn't work
// thing[0].number === 0
// thing[1].number === 0
```

This happens because the buildList method pass the shared options object to the factory. So in the first call of the `factory.options` method the object is empty so the `counter` option will evaluated. The `counter` value will be appended to the shared options object. 
Thus in the moment of the second factory, the shared options object has the value for `counter` previously generated. 

A solution here is clone attributes and options to make sure they will be unique per factory call.

/cc @eventualbuddha 